### PR TITLE
Fix for shutdown ordering issue

### DIFF
--- a/parallel-rdp/rdp_device.hpp
+++ b/parallel-rdp/rdp_device.hpp
@@ -210,10 +210,10 @@ private:
 	std::unique_ptr<ShaderBank> shader_bank;
 #endif
 
+	Renderer renderer;
 	CommandRing ring;
 
 	VideoInterface vi;
-	Renderer renderer;
 
 	void clear_hidden_rdram();
 	void clear_tmem();


### PR DESCRIPTION
This is a potential fix for https://github.com/Themaister/parallel-rdp-standalone/issues/2

It appears that objects are currently being destructed in the incorrect order. The Renderer is shutdown first while the CommandRing is still using it.

I don't have a test case to reliably reproduce this, I'm only going from crash reporting, so I can't say with 100% certainty that this will fix it until I deploy it.